### PR TITLE
Fixed bugs for highlighting multiple conditions

### DIFF
--- a/src/main/kotlin/dev/falsehonesty/PreprocessorHighlightVisitor.kt
+++ b/src/main/kotlin/dev/falsehonesty/PreprocessorHighlightVisitor.kt
@@ -194,16 +194,12 @@ class PreprocessorHighlightVisitor(private val project: Project) : HighlightVisi
         holder.add(info)
     }
 
-    private fun MatchGroup.toNumericOrVariableHighlight(element: PsiCommentImpl, offset: Int = 0): HighlightInfo?
-    {
-        val builder = if (value.trim().toIntOrNull() != null)
-        {
+    private fun MatchGroup.toNumericOrVariableHighlight(element: PsiCommentImpl, offset: Int = 0): HighlightInfo? {
+        val builder = if (value.trim().toIntOrNull() != null) {
             HighlightInfo
                 .newHighlightInfo(NUMBER_TYPE)
                 .textAttributes(NUMBER_ATTRIBUTES)
-        }
-        else
-        {
+        } else {
             HighlightInfo
                 .newHighlightInfo(IDENTIFIER_TYPE)
                 .textAttributes(IDENTIFIER_ATTRIBUTES)
@@ -214,8 +210,7 @@ class PreprocessorHighlightVisitor(private val project: Project) : HighlightVisi
             .create()
     }
 
-    private fun String.toDirectiveHighlight(element: PsiCommentImpl, offset: Int = 0): HighlightInfo?
-    {
+    private fun String.toDirectiveHighlight(element: PsiCommentImpl, offset: Int = 0): HighlightInfo? {
         return HighlightInfo
             .newHighlightInfo(DIRECTIVE_TYPE)
             .textAttributes(DIRECTIVE_ATTRIBUTES)
@@ -223,8 +218,7 @@ class PreprocessorHighlightVisitor(private val project: Project) : HighlightVisi
             .create()
     }
 
-    private fun String.toInvalidConditionErrorHighlight(element: PsiCommentImpl, offset: Int = 0): HighlightInfo?
-    {
+    private fun String.toInvalidConditionErrorHighlight(element: PsiCommentImpl, offset: Int = 0): HighlightInfo? {
         return HighlightInfo
             .newHighlightInfo(HighlightInfoType.ERROR)
             .range(element, element.startOffset + offset, element.startOffset + offset + length)

--- a/src/main/kotlin/dev/falsehonesty/PreprocessorHighlightVisitor.kt
+++ b/src/main/kotlin/dev/falsehonesty/PreprocessorHighlightVisitor.kt
@@ -7,6 +7,7 @@ import com.intellij.codeInsight.daemon.impl.analysis.HighlightInfoHolder
 import com.intellij.lang.Commenter
 import com.intellij.lang.LanguageCommenters
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.colors.CodeInsightColors
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -67,7 +68,7 @@ class PreprocessorHighlightVisitor(private val project: Project) : HighlightVisi
         EditorColorsManager.getInstance()
 
         if (text.startsWith("#")) {
-            val split = text.substring(1).split(" ")
+            val split = text.substring(1).split(WHITESPACES_PATTERN, limit = 2)
 
             when (val command = split[0]) {
                 "if" -> {
@@ -279,6 +280,9 @@ class PreprocessorHighlightVisitor(private val project: Project) : HighlightVisi
         val NUMBER_ATTRIBUTES = TextAttributes.merge(SCHEME.getAttributes(NUMBER_COLOR), BOLD_ATTRIBUTE)
         val NUMBER_TYPE = HighlightInfoType.HighlightInfoTypeImpl(HighlightSeverity.INFORMATION, NUMBER_COLOR)
 
+        private val LOGGER: Logger = Logger.getInstance(PreprocessorHighlightVisitor::class.java)
+
+        private val WHITESPACES_PATTERN = "\\s+".toRegex()
         private val EXPR_PATTERN = "(.+)(<=|>=|<|>)(.+)".toRegex()
         private val OR_PATTERN = Pattern.quote("||")
         private val AND_PATTERN = Pattern.quote("&&")


### PR DESCRIPTION
The bizarre conditions will be highlighted properly now.:

```java
//#if     VAR_1   >    VAR_2  &&  VAR_3< VAR_4
```
